### PR TITLE
Feat: 태그 기능 추가

### DIFF
--- a/app/blog/[category]/(layout)/layout.tsx
+++ b/app/blog/[category]/(layout)/layout.tsx
@@ -1,24 +1,8 @@
 import { siteConfig } from '@/constants/config';
 import { PostCategory } from '@/types/blogType';
-import { calGetPosts } from '@/utils/dataset';
 import { Metadata } from 'next';
 
-const calPostsInfo = (category: PostCategory) => {
-  if (category === 'dev')
-    return {
-      metaTitle: 'jerrychu (제리추) / 프론트엔드 개발 블로그 작성글',
-      metaDesc: 'jerrychu 개발 관련 블로그 포스트 모음',
-      title: 'Dev Blog Posts',
-      desc: '개발 관련 블로그 포스트 모음입니다. 다양한 기술과 경험을 공유합니다.',
-    };
-
-  return {
-    metaTitle: 'jerrychu (제리추) / 일상 블로그 작성글',
-    metaDesc: 'jerrychu 일상 관련 블로그 포스트 모음',
-    title: 'Life Blog Posts',
-    desc: '일상 관련 블로그 포스트 모음입니다. 일상의 경험을 공유합니다.',
-  };
-};
+import { calPostsInfo } from './page';
 
 export async function generateMetadata({
   params,
@@ -47,25 +31,9 @@ export async function generateMetadata({
 }
 
 export default async function PostsLayout({
-  params,
   children,
 }: {
-  params: Promise<{ category: PostCategory }>;
   children: React.ReactNode;
 }) {
-  const { category } = await params;
-
-  const posts = await calGetPosts(category);
-  const postsInfo = calPostsInfo(category);
-  const { title, desc } = postsInfo;
-
-  return (
-    <div className="flex flex-col">
-      <h1 className="mb-4 text-3xl">
-        {title} <span className="text-xl">({posts.length})</span>
-      </h1>
-      <p className="font-arita text-secondary mb-8">{desc}</p>
-      {children}
-    </div>
-  );
+  return <>{children}</>;
 }

--- a/app/blog/[category]/(layout)/layout.tsx
+++ b/app/blog/[category]/(layout)/layout.tsx
@@ -1,8 +1,7 @@
 import { siteConfig } from '@/constants/config';
 import { PostCategory } from '@/types/blogType';
+import { calPostsInfo } from '@/utils/dataset';
 import { Metadata } from 'next';
-
-import { calPostsInfo } from './page';
 
 export async function generateMetadata({
   params,

--- a/app/blog/[category]/(layout)/page.tsx
+++ b/app/blog/[category]/(layout)/page.tsx
@@ -1,6 +1,24 @@
+import BlogIntroduce from '@/components/blog/BlogIntroduce';
 import BlogPosts from '@/components/blog/BlogPosts';
 import { PostCategory } from '@/types/blogType';
 import { calGetPosts, calSortTimePosts } from '@/utils/dataset';
+
+export const calPostsInfo = (category: PostCategory) => {
+  if (category === 'dev')
+    return {
+      metaTitle: 'jerrychu (제리추) / 프론트엔드 개발 블로그 작성글',
+      metaDesc: 'jerrychu 개발 관련 블로그 포스트 모음',
+      title: 'Dev Blog Posts',
+      desc: '개발 관련 블로그 포스트 모음입니다. 다양한 기술과 경험을 공유합니다.',
+    };
+
+  return {
+    metaTitle: 'jerrychu (제리추) / 일상 블로그 작성글',
+    metaDesc: 'jerrychu 일상 관련 블로그 포스트 모음',
+    title: 'Life Blog Posts',
+    desc: '일상 관련 블로그 포스트 모음입니다. 일상의 경험을 공유합니다.',
+  };
+};
 
 export default async function page({
   params,
@@ -11,5 +29,14 @@ export default async function page({
   const posts = await calGetPosts(category);
   const sortPosts = calSortTimePosts(posts);
 
-  return <BlogPosts sortPosts={sortPosts} />;
+  const postsInfo = calPostsInfo(category);
+  const { title, desc } = postsInfo;
+
+  return (
+    <div className="flex flex-col">
+      <BlogIntroduce title={title} desc={desc} postLength={posts.length} />
+      {/* <BlogSearch /> */}
+      <BlogPosts sortPosts={sortPosts} />
+    </div>
+  );
 }

--- a/app/blog/[category]/(layout)/page.tsx
+++ b/app/blog/[category]/(layout)/page.tsx
@@ -2,42 +2,12 @@ import BlogIntroduce from '@/components/blog/BlogIntroduce';
 import BlogPosts from '@/components/blog/BlogPosts';
 import BlogTags from '@/components/blog/BlogTags';
 import { PostCategory, PostMeta } from '@/types/blogType';
-import { calGetPosts, calSortTimePosts } from '@/utils/dataset';
-
-export const calPostsInfo = (category: PostCategory) => {
-  if (category === 'dev')
-    return {
-      metaTitle: 'jerrychu (제리추) / 프론트엔드 개발 블로그 작성글',
-      metaDesc: 'jerrychu 개발 관련 블로그 포스트 모음',
-      title: 'Dev Blog Posts',
-      desc: '개발 관련 블로그 포스트 모음입니다. 다양한 기술과 경험을 공유합니다.',
-    };
-
-  return {
-    metaTitle: 'jerrychu (제리추) / 일상 블로그 작성글',
-    metaDesc: 'jerrychu 일상 관련 블로그 포스트 모음',
-    title: 'Life Blog Posts',
-    desc: '일상 관련 블로그 포스트 모음입니다. 일상의 경험을 공유합니다.',
-  };
-};
-
-const calTagPosts = (sortPosts: PostMeta[]) => {
-  const filterPosts = sortPosts.reduce(
-    (acc: { [key: string]: PostMeta[] }, cur) => {
-      const { tags } = cur;
-      const sliceTags = tags.slice(0, 2);
-
-      for (const tag of sliceTags) {
-        if (!acc[tag]) acc[tag] = [];
-        acc[tag].push(cur);
-      }
-
-      return acc;
-    },
-    { all: sortPosts },
-  );
-  return filterPosts;
-};
+import {
+  calGetPosts,
+  calPostsInfo,
+  calSortTimePosts,
+  calTagPosts,
+} from '@/utils/dataset';
 
 export default async function page({
   params,

--- a/components/blog/BlogIntroduce.tsx
+++ b/components/blog/BlogIntroduce.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+interface BlogIntroduceProps {
+  title: string;
+  desc: string;
+  postLength: number;
+}
+
+export default function BlogIntroduce({
+  title,
+  desc,
+  postLength,
+}: BlogIntroduceProps) {
+  return (
+    <>
+      <h1 className="mb-4 text-3xl">
+        {title} <span className="text-xl">({postLength})</span>
+      </h1>
+      <p className="font-arita text-secondary mb-8">{desc}</p>
+    </>
+  );
+}

--- a/components/blog/BlogPosts.tsx
+++ b/components/blog/BlogPosts.tsx
@@ -2,53 +2,55 @@
 
 import { useRef } from 'react';
 
-import useSearch from '@/hooks/useSearch';
 import { PostMeta } from '@/types/blogType';
 import { motion, useInView } from 'framer-motion';
 
 import Post from '../common/PostCard';
 
-export default function BlogPosts({ sortPosts }: { sortPosts: PostMeta[] }) {
-  const { debounceWords, calFilterPost } = useSearch();
-  const filterPosts = calFilterPost(sortPosts, debounceWords);
-
+const BlogPosts = ({ posts }: { posts: PostMeta[] }) => {
   return (
     <div className="flex flex-col gap-6 md:grid md:grid-cols-3">
-      {filterPosts.map((item: PostMeta) => {
-        const ref = useRef(null);
-        const isInView = useInView(ref, { amount: 0.3, once: true });
-
-        const {
-          name,
-          title,
-          date,
-          image: imageSrc,
-          category,
-          link,
-          description,
-        } = item;
-
-        return (
-          <motion.article
-            key={name}
-            ref={ref}
-            initial={{ opacity: 0, y: 20 }}
-            animate={isInView && { opacity: 1, y: 0 }}
-            transition={{ duration: 0.5 }}
-          >
-            <Post
-              key={name}
-              name={name}
-              title={title}
-              description={description}
-              date={date}
-              imageSrc={imageSrc}
-              category={category}
-              link={link}
-            />
-          </motion.article>
-        );
-      })}
+      {posts.map((item) => (
+        <BlogPost key={item.name} {...item} />
+      ))}
     </div>
   );
+};
+
+function BlogPost({ ...item }) {
+  const ref = useRef(null);
+  const isInView = useInView(ref, { amount: 0.3, once: true });
+
+  const {
+    name,
+    title,
+    date,
+    image: imageSrc,
+    category,
+    link,
+    description,
+  } = item;
+
+  return (
+    <motion.article
+      key={name}
+      ref={ref}
+      initial={{ opacity: 0, y: 20 }}
+      animate={isInView && { opacity: 1, y: 0 }}
+      transition={{ duration: 0.5 }}
+    >
+      <Post
+        key={name}
+        name={name}
+        title={title}
+        description={description}
+        date={date}
+        imageSrc={imageSrc}
+        category={category}
+        link={link}
+      />
+    </motion.article>
+  );
 }
+
+export default BlogPosts;

--- a/components/blog/BlogPosts.tsx
+++ b/components/blog/BlogPosts.tsx
@@ -2,19 +2,31 @@
 
 import { useRef } from 'react';
 
+import useSearch from '@/hooks/useSearch';
 import { PostMeta } from '@/types/blogType';
 import { motion, useInView } from 'framer-motion';
 
 import Post from '../common/PostCard';
 
 export default function BlogPosts({ sortPosts }: { sortPosts: PostMeta[] }) {
+  const { debounceWords, calFilterPost } = useSearch();
+  const filterPosts = calFilterPost(sortPosts, debounceWords);
+
   return (
     <div className="flex flex-col gap-6 md:grid md:grid-cols-3">
-      {sortPosts.map((item: PostMeta) => {
+      {filterPosts.map((item: PostMeta) => {
         const ref = useRef(null);
         const isInView = useInView(ref, { amount: 0.3, once: true });
 
-        const { name, title, date, image: imageSrc, category, link } = item;
+        const {
+          name,
+          title,
+          date,
+          image: imageSrc,
+          category,
+          link,
+          description,
+        } = item;
 
         return (
           <motion.article
@@ -28,6 +40,7 @@ export default function BlogPosts({ sortPosts }: { sortPosts: PostMeta[] }) {
               key={name}
               name={name}
               title={title}
+              description={description}
               date={date}
               imageSrc={imageSrc}
               category={category}

--- a/components/blog/BlogTags.tsx
+++ b/components/blog/BlogTags.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import React from 'react';
+
+import { PostCategory, PostMeta } from '@/types/blogType';
+import { useRouter } from 'next/navigation';
+
+import Tag from '../common/Tag';
+
+interface BlogTagsProps {
+  category: PostCategory;
+  tagPosts: Record<string, PostMeta[]>;
+}
+
+export default function BlogTags({ category, tagPosts }: BlogTagsProps) {
+  const router = useRouter();
+
+  const handleTag = (tagName: string) => {
+    router.push(`/blog/${category}?tag=${tagName}`);
+  };
+
+  return (
+    <div className="custom-scrollbar mb-1 flex h-[1.8rem] w-full gap-1 overflow-x-auto whitespace-nowrap">
+      {Object.keys(tagPosts).map((name) => (
+        <Tag key={name} onclick={() => handleTag(name)}>
+          {name === 'all'
+            ? `전체보기 (${tagPosts[name].length})`
+            : `${name} (${tagPosts[name].length})`}
+        </Tag>
+      ))}
+    </div>
+  );
+}

--- a/components/common/PostCard.tsx
+++ b/components/common/PostCard.tsx
@@ -13,6 +13,7 @@ export interface PostProps {
   imageSrc: string;
   category: PostCategory;
   link?: string;
+  description: string;
 }
 
 export default function PostCard({
@@ -21,6 +22,7 @@ export default function PostCard({
   date,
   imageSrc,
   category,
+  description,
   link,
 }: PostProps) {
   const categoryLabel = category === 'dev' ? 'Dev' : 'Life';
@@ -39,17 +41,20 @@ export default function PostCard({
           sizes="(max-width: 768px) 100vw, 50vw"
         />
       </div>
-      <div className="bg-thirdary flex-[1] rounded-b-lg px-4 py-2">
-        <div className="font-caveat mb-[0.5rem] flex items-center justify-between text-[0.875rem]">
+      <div className="bg-thirdary relative flex-[1] rounded-b-lg px-4 pt-3 pb-2">
+        <h3 className="font-arita mb-2 line-clamp-2 text-[0.875rem] leading-5 font-semibold">
+          {title}
+        </h3>
+        <p className="font-arita text-secondary mb-[2.4rem] line-clamp-2 min-h-[2rem] overflow-hidden text-xs">
+          {description}
+        </p>
+        <div className="font-caveat absolute inset-x-0 bottom-1 flex w-full items-center justify-between px-4 text-[0.875rem]">
           <div>
             <span>{categoryLabel} ﹒ </span>
             <time className="font-caveat">{transformDate}</time>
           </div>
           {link && <ExternalIcon />}
         </div>
-        <h3 className="font-arita line-clamp-1 text-[0.875rem] font-semibold">
-          {title}
-        </h3>
       </div>
     </>
   );

--- a/components/common/PostCard.tsx
+++ b/components/common/PostCard.tsx
@@ -64,7 +64,7 @@ export default function PostCard({
     return (
       <LinkExternal
         href={link}
-        className="flex h-full cursor-pointer flex-col"
+        className="flex h-full cursor-pointer flex-col rounded-t-lg"
         aria-label={`${title} (새 창으로 열림)`}
       >
         {commonContent}
@@ -76,7 +76,7 @@ export default function PostCard({
   return (
     <Link
       href={`/blog/${category}/${name}`}
-      className="flex h-full cursor-pointer flex-col"
+      className="flex h-full cursor-pointer flex-col rounded-t-lg"
     >
       {commonContent}
     </Link>

--- a/components/common/Tag.tsx
+++ b/components/common/Tag.tsx
@@ -7,7 +7,7 @@ export default function Tag({
 }) {
   return (
     <button
-      className="bg-thirdary font-pretandard hover:text h-fit w-fit shrink-0 cursor-pointer rounded-lg px-2 py-0.5 text-xs text-nowrap transition-colors hover:bg-gray-300"
+      className="bg-thirdary border-thirdary font-pretandard hover:text h-fit w-fit shrink-0 cursor-pointer rounded-lg border-1 px-2 py-0.5 text-xs text-nowrap transition-colors hover:bg-gray-300"
       onClick={onclick}
       aria-label={`${children}로 필터링`}
     >

--- a/components/common/Tag.tsx
+++ b/components/common/Tag.tsx
@@ -1,0 +1,17 @@
+export default function Tag({
+  children,
+  onclick,
+}: {
+  children: React.ReactNode;
+  onclick: () => void;
+}) {
+  return (
+    <button
+      className="bg-thirdary font-pretandard hover:text h-fit w-fit shrink-0 cursor-pointer rounded-lg px-2 py-0.5 text-xs text-nowrap transition-colors hover:bg-gray-300"
+      onClick={onclick}
+      aria-label={`${children}로 필터링`}
+    >
+      {children}
+    </button>
+  );
+}

--- a/components/home/HomePosts.tsx
+++ b/components/home/HomePosts.tsx
@@ -42,7 +42,6 @@ export default function HomePosts({
       className="flex flex-col gap-6 md:grid md:grid-cols-3"
     >
       {changesImagesPosts.map((item) => {
-        console.log(item);
         const {
           name,
           title,

--- a/components/home/HomePosts.tsx
+++ b/components/home/HomePosts.tsx
@@ -42,7 +42,16 @@ export default function HomePosts({
       className="flex flex-col gap-6 md:grid md:grid-cols-3"
     >
       {changesImagesPosts.map((item) => {
-        const { name, title, date, image: imageSrc, category, link } = item;
+        console.log(item);
+        const {
+          name,
+          title,
+          date,
+          image: imageSrc,
+          category,
+          link,
+          description,
+        } = item;
         return (
           <motion.article key={title} variants={itemVriants}>
             <PostCard
@@ -50,6 +59,7 @@ export default function HomePosts({
               name={name}
               title={title}
               date={date}
+              description={description}
               imageSrc={imageSrc}
               category={category}
               link={link}

--- a/components/layout/Header/index.tsx
+++ b/components/layout/Header/index.tsx
@@ -1,13 +1,16 @@
-import React from 'react';
+'use client';
 
 import ThemeButton from '@/components/common/ThemeButton';
 import { siteConfig } from '@/constants/config';
-import Image, { StaticImageData } from 'next/image';
+import { cn } from '@/utils/cn';
 import Link from 'next/link';
+import { usePathname } from 'next/navigation';
 
 const NAV_LINKS = siteConfig.menus;
 
-const Header = React.memo(() => {
+const Header = () => {
+  const pathname = usePathname();
+
   return (
     <header className="flex h-20 w-full items-center justify-between pt-4 pb-8 select-none">
       <nav className="flex gap-4">
@@ -16,7 +19,10 @@ const Header = React.memo(() => {
             <Link
               key={item.label}
               href={item.href}
-              className="font-caveat text-xl"
+              className={cn(
+                'font-caveat text-xl',
+                pathname === item.href && 'font-semibold',
+              )}
             >
               {item.label}
             </Link>
@@ -26,6 +32,6 @@ const Header = React.memo(() => {
       <ThemeButton />
     </header>
   );
-});
+};
 
 export default Header;

--- a/styles/global.css
+++ b/styles/global.css
@@ -34,6 +34,28 @@
     font-size: 1.5rem;
     line-height: 1.75rem;
   }
+
+  .custom-scrollbar::-webkit-scrollbar {
+    height: 0px;
+  }
+
+  .custom-scrollbar:hover::-webkit-scrollbar {
+    height: 6px;
+  }
+
+  .custom-scrollbar::-webkit-scrollbar-track {
+    background: #f1f1f1;
+    border-radius: 3px;
+  }
+
+  .custom-scrollbar::-webkit-scrollbar-thumb {
+    background: #c1c1c1;
+    border-radius: 3px;
+  }
+
+  .custom-scrollbar::-webkit-scrollbar-thumb:hover {
+    background: #a8a8a8;
+  }
 }
 
 @layer utilities {
@@ -44,4 +66,26 @@
   .pl-content {
     padding-left: var(--container-contentMarginLeft);
   }
+
+  /* .custom-scrollbar::-webkit-scrollbar {
+    height: 0px;
+  }
+
+  .custom-scrollbar:hover::-webkit-scrollbar {
+    height: 6px;
+  }
+
+  .custom-scrollbar::-webkit-scrollbar-track {
+    background: #f1f1f1;
+    border-radius: 3px;
+  }
+
+  .custom-scrollbar::-webkit-scrollbar-thumb {
+    background: #c1c1c1;
+    border-radius: 3px;
+  }
+
+  .custom-scrollbar::-webkit-scrollbar-thumb:hover {
+    background: #a8a8a8;
+  } */
 }

--- a/utils/dataset.ts
+++ b/utils/dataset.ts
@@ -2,6 +2,32 @@ import { PostCategory, PostMeta } from '@/types/blogType';
 import { readdir } from 'fs/promises';
 import path from 'path';
 
+/**
+ * 게시물 목록을 받아 태그별로 그룹화한 객체를 반환합니다.
+ * - 각 게시물의 상위 2개 태그만 사용합니다.
+ * - 'all' 키에는 전체 게시물을 저장합니다.
+ *
+ * @param sortPosts 정렬된 게시물 배열
+ * @returns 태그별로 분류된 게시물 객체 (예: { react: [...], nextjs: [...], all: [...] })
+ */
+export const calTagPosts = (sortPosts: PostMeta[]) => {
+  const filterPosts = sortPosts.reduce(
+    (acc: { [key: string]: PostMeta[] }, cur) => {
+      const { tags } = cur;
+      const sliceTags = tags.slice(0, 2);
+
+      for (const tag of sliceTags) {
+        if (!acc[tag]) acc[tag] = [];
+        acc[tag].push(cur);
+      }
+
+      return acc;
+    },
+    { all: sortPosts },
+  );
+  return filterPosts;
+};
+
 // 최신 날짜 기준으로 정렬
 export const calSortTimePosts = (posts: PostMeta[]) => {
   const sortTimePost = posts.sort(
@@ -39,3 +65,20 @@ export async function calGetAllPosts() {
   const allPosts = [...devPosts, ...lifePosts];
   return allPosts;
 }
+
+export const calPostsInfo = (category: PostCategory) => {
+  if (category === 'dev')
+    return {
+      metaTitle: 'jerrychu (제리추) / 프론트엔드 개발 블로그 작성글',
+      metaDesc: 'jerrychu 개발 관련 블로그 포스트 모음',
+      title: 'Dev Blog Posts',
+      desc: '개발 관련 블로그 포스트 모음입니다. 다양한 기술과 경험을 공유합니다.',
+    };
+
+  return {
+    metaTitle: 'jerrychu (제리추) / 일상 블로그 작성글',
+    metaDesc: 'jerrychu 일상 관련 블로그 포스트 모음',
+    title: 'Life Blog Posts',
+    desc: '일상 관련 블로그 포스트 모음입니다. 일상의 경험을 공유합니다.',
+  };
+};


### PR DESCRIPTION
## 📝 PR 제목
feat: 블로그 포스트 태그 필터링 기능 구현

## ✅ 개요
블로그 글 목록 페이지에 태그 필터 기능을 추가했습니다.
사용자는 태그 버튼을 클릭하여 해당 태그가 포함된 게시물만 필터링할 수 있습니다.
SSR 기반으로 태그별 포스트 목록과 개수를 계산해 렌더링합니다.

 ## 🔧 주요 변경 사항
1. Tag 컴포넌트 추가
2. BlogTags 컴포넌트 추가
3. page.tsx
SSR에서 tag 쿼리 파라미터 수신 (searchParams)
전체 게시물 → 태그별 게시물 필터링 적용
BlogPosts, BlogTags로 데이터 전달

## 📁 관련 파일 구조
- components/
  - blog/
    - BlogTags.tsx
    - BlogPosts.tsx
    - BlogIntroduce.tsx