### PR TITLE
feat: google adsense 인증 account 추가

### DIFF
--- a/constants/config.ts
+++ b/constants/config.ts
@@ -55,6 +55,7 @@ export const seoConfig: Metadata = {
     google: 'YV2XiZ4p2B-EZQUYFMOORXahkH7uzy9A6vm6xZPP_t4',
     other: {
       'naver-site-verification': 'cd6fa7075e8d25586ca69d55a9b97c36db3600c6',
+      'google-adsense-account': 'ca-pub-4761019594552611',
     },
   },
   openGraph: {


### PR DESCRIPTION
## 🔧 작업 개요

Google adsense 인증 account meta tag 추가

## ✅ 작업 항목

- [x] 광고 단위 생성 및 코드 스니펫 확보 (메타 태그 대체)
- [x] Google AdSense 또는 Google Ad Manager 계정 설정

## ✨ 신규 기능 / 개선

- 광고 단위 생성 및 코드 스니펫 확보 (메타 태그 추가)
