### PR TITLE
refactor: blog wrapper 컴포넌트 생성 및 prefetch true 설정

### DIFF
--- a/features/blog/BlogPostWrapper.tsx
+++ b/features/blog/BlogPostWrapper.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import React, { useRef } from 'react';
+
+import { motion, useInView } from 'framer-motion';
+
+interface BlogPostWrapperProps {
+  children: React.ReactNode;
+}
+
+export function BlogPostWrapper({ children }: BlogPostWrapperProps) {
+  const ref = useRef(null);
+  const isInView = useInView(ref, { amount: 0.3, once: true });
+
+  return (
+    <motion.article
+      ref={ref}
+      initial={{ opacity: 0, y: 20 }}
+      animate={isInView && { opacity: 1, y: 0 }}
+      transition={{ duration: 0.5 }}
+    >
+      {children}
+    </motion.article>
+  );
+}

--- a/features/blog/BlogPosts.tsx
+++ b/features/blog/BlogPosts.tsx
@@ -1,53 +1,27 @@
-'use client';
-
-import { useRef } from 'react';
-
 import { PostMeta } from '@/shared/types/blogType';
 import { PostCard } from '@/widgets';
-import { motion, useInView } from 'framer-motion';
+
+import { BlogPostWrapper } from './BlogPostWrapper';
 
 export const BlogPosts = ({ posts }: { posts: PostMeta[] }) => {
   return (
     <div className="flex flex-col gap-6 md:grid md:grid-cols-3">
-      {posts.map((item) => (
-        <BlogPost key={item.name} {...item} />
-      ))}
+      {posts.map((item) => {
+        const { name, title, description, date, image, category, link } = item;
+        return (
+          <BlogPostWrapper key={name}>
+            <PostCard
+              name={name}
+              title={title}
+              description={description}
+              date={date}
+              imageSrc={image}
+              category={category}
+              link={link}
+            />
+          </BlogPostWrapper>
+        );
+      })}
     </div>
   );
 };
-
-function BlogPost({ ...item }) {
-  const ref = useRef(null);
-  const isInView = useInView(ref, { amount: 0.3, once: true });
-
-  const {
-    name,
-    title,
-    date,
-    image: imageSrc,
-    category,
-    link,
-    description,
-  } = item;
-
-  return (
-    <motion.article
-      key={name}
-      ref={ref}
-      initial={{ opacity: 0, y: 20 }}
-      animate={isInView && { opacity: 1, y: 0 }}
-      transition={{ duration: 0.5 }}
-    >
-      <PostCard
-        key={name}
-        name={name}
-        title={title}
-        description={description}
-        date={date}
-        imageSrc={imageSrc}
-        category={category}
-        link={link}
-      />
-    </motion.article>
-  );
-}

--- a/features/blog/index.ts
+++ b/features/blog/index.ts
@@ -1,3 +1,4 @@
 export { BlogIntroduce } from './BlogIntroduce';
 export { BlogTags } from './BlogTags';
 export { BlogPosts } from './BlogPosts';
+export { BlogPostWrapper } from './BlogPostWrapper';

--- a/widgets/PostCard.tsx
+++ b/widgets/PostCard.tsx
@@ -77,6 +77,7 @@ export function PostCard({
     <Link
       href={`/blog/${category}/${name}`}
       className="flex h-full cursor-pointer flex-col rounded-t-lg"
+      prefetch={true}
     >
       {commonContent}
     </Link>


### PR DESCRIPTION
## 🔧 작업 개요

Blog 페이지의 레이아웃 및 링크 최적화를 위한 Wrapper 컴포넌트 분리 작업

## ✅ 작업 항목

 - [x] BlogWrapper 컴포넌트 생성
 - [x] 각 포스트 링크에 prefetch={true} 설정

## ✨ 신규 기능 / 개선

- BlogWrapper 컴포넌트를 분리하여 레이아웃 구조 개선
- Link 컴포넌트에 prefetch={true}를 설정해 해당 페이지의 데이터를 사전 요청

## 🤔 고려사항

- prefetch 기본 값이 Next 15는 null이래서 설정
- RSC 기반 페이지에서 과도한 prefetch 주의하며 설정